### PR TITLE
FIX loopback/vteps based on 3rd octet of mgmt_ip

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/defaults/main/default-templates.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/defaults/main/default-templates.yml
@@ -34,12 +34,12 @@ default_templates:
           list_merge: "{{ custom_structured_configuration_list_merge }}"
           strip_empty_keys: false
     ip_addressing:
-      router_id: 'designs/l3ls-evpn/ip-addressing/router-id.j2'
+      router_id: 'designs/l3ls-evpn/ip-addressing/router-id-lastoctet.j2'
       mlag_ip_primary: 'designs/l3ls-evpn/ip-addressing/mlag-ip-primary-fixed.j2'
       mlag_ip_secondary: 'designs/l3ls-evpn/ip-addressing/mlag-ip-secondary-fixed.j2'
       mlag_l3_ip_primary: 'designs/l3ls-evpn/ip-addressing/mlag-l3-ip-primary-fixed.j2'
       mlag_l3_ip_secondary: 'designs/l3ls-evpn/ip-addressing/mlag-l3-ip-secondary-fixed.j2'
       p2p_uplinks_ip: 'designs/l3ls-evpn/ip-addressing/p2p-uplinks-ip.j2'
       p2p_uplinks_peer_ip: 'designs/l3ls-evpn/ip-addressing/p2p-uplinks-peer-ip.j2'
-      vtep_ip_mlag: 'designs/l3ls-evpn/ip-addressing/vtep-ip-mlag.j2'
-      vtep_ip: 'designs/l3ls-evpn/ip-addressing/vtep-ip.j2'
+      vtep_ip_mlag: 'designs/l3ls-evpn/ip-addressing/vtep-ip-mlag-lastoctet.j2'
+      vtep_ip: 'designs/l3ls-evpn/ip-addressing/vtep-ip-lastoctet.j2'

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/ip-addressing/router-id-lastoctet.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/ip-addressing/router-id-lastoctet.j2
@@ -1,0 +1,3 @@
+{% set mgmt_ip = switch_data.node.mgmt_ip | ansible.netcommon.ipaddr("address") %}
+{% set mgmt_ip_last_octet = mgmt_ip.split('.')[3] | int  %}
+{{ loopback_ipv4_pool | ansible.netcommon.ipaddr("network") | ansible.netcommon.ipmath( mgmt_ip_last_octet ) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/ip-addressing/vtep-ip-lastoctet.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/ip-addressing/vtep-ip-lastoctet.j2
@@ -1,0 +1,3 @@
+{% set mgmt_ip = switch_data.node.mgmt_ip | ansible.netcommon.ipaddr("address") %}
+{% set mgmt_ip_last_octet = mgmt_ip.split('.')[3] | int  %}
+{{ switch_vtep_loopback_ipv4_pool | ansible.netcommon.ipaddr("network") | ansible.netcommon.ipmath( mgmt_ip_last_octet ) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/ip-addressing/vtep-ip-mlag-lastoctet.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/designs/l3ls-evpn/ip-addressing/vtep-ip-mlag-lastoctet.j2
@@ -1,0 +1,14 @@
+{%  if switch_data.node_group.nodes.keys() | list | first == inventory_hostname %}
+{%      set mgmt_ip_addr = switch_data.node_group.nodes[inventory_hostname].mgmt_ip | ansible.netcommon.ipaddr("address") %}
+{%      set mlag_primary_id = mgmt_ip_addr.split('.')[3] | int %}
+{%      set mlag_peer_hostname = switch_data.node_group.nodes.keys() | list | last %}
+{%      set mgmt_ip_addr = switch_data.node_group.nodes[mlag_peer_hostname].mgmt_ip | ansible.netcommon.ipaddr('address') %}
+{%      set mlag_secondary_id = mgmt_ip_addr.split('.')[3] | int %}
+{%  elif switch_data.node_group.nodes.keys()| list | last == inventory_hostname %}
+{%      set mgmt_ip_addr = switch_data.node_group.nodes[inventory_hostname].mgmt_ip | ansible.netcommon.ipaddr("address") %}
+{%      set mlag_secondary_id = mgmt_ip_addr.split('.')[3] | int %}
+{%      set mlag_peer_hostname = switch_data.node_group.nodes.keys()| list | first %}
+{%      set mgmt_ip_addr = switch_data.node_group.nodes[mlag_peer_hostname].mgmt_ip | ansible.netcommon.ipaddr('address') %}
+{%      set mlag_primary_id = mgmt_ip_addr.split('.')[3] | int %}
+{%  endif %}
+{{ switch_vtep_loopback_ipv4_pool | ansible.netcommon.ipaddr('network') | ansible.netcommon.ipmath(mlag_primary_id ) }}


### PR DESCRIPTION
## Change Summary

Loopback IPs and VTEPs IPs are now based on 3rd octet of management IP address. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
using 3rd octet of mgmt_ip instead of switch_id to generate loopback addresses and vtep addresses.

no changes to the data model. 

## How to test
<!--- Please describe in detail how you tested your changes. -->
./build mtl_prx_ctrl_update generates the correct IPs for loopback and vteps. 

./build tor_prx_ctrl_update also generates the correct IPs for loopback and vteps. 

<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from media-cli-fixes before I start
- [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
