### PR TITLE
ADD support for ip igmp snooping querier

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-igmp-snooping.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-igmp-snooping.j2
@@ -2,7 +2,7 @@
 {% if ip_igmp_snooping.globally_enabled is arista.avd.defined(false) %}
 !
 no ip igmp snooping
-{% elif ip_igmp_snooping.querier_enabled is arista.avd.defined(true) %}
+{% elif ip_igmp_snooping.querier.enabled is arista.avd.defined(true) %}
 !
 ip igmp snooping querier
 {% elif ip_igmp_snooping.vlans is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-igmp-snooping.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-igmp-snooping.j2
@@ -2,6 +2,9 @@
 {% if ip_igmp_snooping.globally_enabled is arista.avd.defined(false) %}
 !
 no ip igmp snooping
+{% elif ip_igmp_snooping.querier_enabled is arista.avd.defined(true) %}
+!
+ip igmp snooping querier
 {% elif ip_igmp_snooping.vlans is arista.avd.defined %}
 !
 {%     for vlan in ip_igmp_snooping.vlans | arista.avd.natural_sort %}


### PR DESCRIPTION
## Change Summary

Adding support for the configuration 
ip igmp snooping querier

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
The configuration 

ip_igmp_snooping: 
  querier_enabled: true

will generate the following cli: 

!
ip igmp snooping querier

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from media-cli-fixes before I start
- [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly
- [ ] All new and existing tests passed ([`pre-commit`](https://www.avd.sh/docs/installation/development/#python-virtual-environment), `make linting` and `make sanity-lint`).
