### PR TITLE
FIX type in eos-intended-config.j2

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -99,7 +99,7 @@
 {# users #}
 {% include 'eos/local-users.j2' %}
 {## Roles #}
-{% include 'documentation/roles.j2' %}
+{% include 'eos/roles.j2' %}
 {# clock timezone #}
 {% include 'eos/clock-timezone.j2' %}
 {# VLANs #}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->

FIX a type in eos-intended-config.j2 

it was including the documentation roles.j2 instead of the eos roles.j2