### PR TITLE
  Add the ability for the user the define the port-channel ID instead…

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/ethernet-interfaces.j2
@@ -17,7 +17,11 @@ ethernet_interfaces:
 {%             set peer = connected_endpoint %}
 {%             for adapter_switch in adapter.switches %}
 {%                 if adapter_switch == inventory_hostname %}
-{%                     set channel_group_id = (adapter.switch_ports[0] | regex_findall("\d") | join) %}
+{%                     if adapter.port_channel.id is arista.avd.defined %}
+{%                         set channel_group_id = adapter.port_channel.id %}
+{%                     else  %}
+{%                         set channel_group_id = (adapter.switch_ports[0] | regex_findall("\d") | join) %}
+{%                     endif %}
 {%                     set peer_interface = endpoint_ports[loop.index0] %}
   {{ adapter.switch_ports[loop.index0] }}:
     peer: {{ peer }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/connected_endpoints/port-channel-interfaces.j2
@@ -13,7 +13,11 @@ port_channel_interfaces:
                                                    adapter_profile | arista.avd.default({}),
                                                    adapter, recursive=true, list_merge='replace') %}
 {%             if adapter_settings.port_channel.mode is arista.avd.defined %}
-{%                 set channel_group_id = (adapter.switch_ports[0] | regex_findall("\d") | join) %}
+{%                     if adapter.port_channel.id is arista.avd.defined %}
+{%                         set channel_group_id = adapter.port_channel.id %}
+{%                     else  %}
+{%                         set channel_group_id = (adapter.switch_ports[0] | regex_findall("\d") | join) %}
+{%                     endif %}
 {%                 set adapter_port_channel_description = adapter_settings.port_channel.description | arista.avd.default('') %}
 {%                 for adapter_switch in adapter.switches | arista.avd.natural_sort %}
 {%                     if adapter_switch == inventory_hostname %}


### PR DESCRIPTION
… of AVD

## Change Summary

<!-- Enter short PR description -->

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.<role-name>`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
